### PR TITLE
Add a dummy CSP endpoint for local dev

### DIFF
--- a/addons.conf
+++ b/addons.conf
@@ -21,6 +21,12 @@ server {
     location / {
         proxy_pass http://web/;
     }
+
+    # Return 204 for CSP reports to save sending them
+    # into Django.
+    location /csp-report {
+        return 204;
+    }
 }
 
 upstream web {


### PR DESCRIPTION
This a nginx endpoint for CSP in dev which will return 204 for reports for local-dev only.
