### PR TITLE
Pass correct Host header.

### DIFF
--- a/addons.conf
+++ b/addons.conf
@@ -24,6 +24,7 @@ server {
 
     location / {
         proxy_pass http://web/;
+        proxy_set_header Host $http_host;
     }
 
     # Return 204 for CSP reports to save sending them


### PR DESCRIPTION
Refs mozilla/addons-server#3347

This should pass on the browsers `Host` header to the proxy. Hoping this fixes various of errors we see and actually works...