### PR TITLE
Default requests to addons-frontend and fall back to addons-server.

### DIFF
--- a/addons.conf
+++ b/addons.conf
@@ -35,6 +35,10 @@ server {
         proxy_pass http://web/static/admin/;
     }
 
+    location ~ ^/api/(v3|v4)/ {
+        try_files $uri @olympia;
+    }
+
     location / {
         try_files $uri @frontendamo;
     }

--- a/addons.conf
+++ b/addons.conf
@@ -2,6 +2,12 @@ client_max_body_size 50m;
 etag off;
 merge_slashes off;
 
+
+map $http_user_agent $mobile_agents {
+    default 0;
+    ~*(android|fennec|iemobile|iphone|opera\w(?:mini|mobi)|mozilla.+mobile|android|fennec|iemobile) 1;
+}
+
 server {
     listen  80 default;
 
@@ -30,8 +36,54 @@ server {
     }
 
     location / {
-        proxy_pass http://web/;
+        try_files $uri @frontendamo;
+    }
+
+    location @olympia {
+        # We are using uwsgi in our dev, stage and prod environments
+        # but not yet for our local development. So let's simply do a
+        # proxa_pass here to redirect to the django runserver.
+        proxy_pass http://web;
+        proxy_set_header X-FORWARDED-PROTOCOL "ssl";
         proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        proxy_connect_timeout 30;
+        proxy_read_timeout 30;
+
+        # pass X_IS_MOBILE_AGENTS header per https://bugzilla.mozilla.org/show_bug.cgi?id=1361323#c11
+        proxy_set_header X_IS_MOBILE_AGENTS $mobile_agents;
+        add_header Vary User-Agent;
+    }
+
+    location @frontendamo {
+        proxy_pass http://addons-frontend;
+        proxy_buffers 16 32k;
+        proxy_buffer_size 128k;
+        proxy_pass_header Server;
+        proxy_set_header X-FORWARDED-PROTOCOL "ssl";
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+        proxy_connect_timeout 30;
+        proxy_read_timeout 30;
+
+        # pass X_IS_MOBILE_AGENTS header per https://bugzilla.mozilla.org/show_bug.cgi?id=1361323#c11
+        proxy_set_header X_IS_MOBILE_AGENTS $mobile_agents;
+        add_header Vary User-Agent;
+
+        # A small workaround to redirect everything that would 404
+        # on addons-frontend to the django server.
+        # This way we don't have to copy the hundreds of entries
+        # from our prod config.
+        error_page 404 = @olympia;
+
+        # This is required to actually bubble up the 404 error from
+        # addons frontend so that nginx can act on it.
+        proxy_intercept_errors on;
+
     }
 
     # Return 204 for CSP reports to save sending them
@@ -41,6 +93,11 @@ server {
     }
 }
 
+# Use the names from our docker setup
 upstream web {
     server web:8000;
+}
+
+upstream addons-frontend {
+    server addons-frontend:3000;
 }

--- a/addons.conf
+++ b/addons.conf
@@ -50,7 +50,7 @@ server {
     location @olympia {
         # We are using uwsgi in our dev, stage and prod environments
         # but not yet for our local development. So let's simply do a
-        # proxa_pass here to redirect to the django runserver.
+        # proxy_pass here to redirect to the django runserver.
         proxy_pass http://web;
         proxy_set_header X-FORWARDED-PROTOCOL "ssl";
         proxy_set_header Host $http_host;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/9080

Todo:

* [x] At least optimize API access for performance, default `/api/v3|v4/` requests to hit olympia directly