### PR TITLE
Allow /api/v5/

### DIFF
--- a/addons.conf
+++ b/addons.conf
@@ -39,7 +39,7 @@ server {
         proxy_pass http://web/static/admin/;
     }
 
-    location ~ ^/api/(v3|v4|v4dev)/ {
+    location ~ ^/api/(v3|v4|v5)/ {
         try_files $uri @olympia;
     }
 


### PR DESCRIPTION
I had trouble setting up a local env with code-manger and addons-server. This is needed to hopefully run code-manager locally with a local olympia instance.