### PR TITLE
Changing Nginx to alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx
+FROM nginx:alpine
 EXPOSE 80
 ADD addons.conf /etc/nginx/conf.d/addons.conf


### PR DESCRIPTION
It would be useful to use the alpine version of Nginx as it makes the container ultra-light.