### PR TITLE
Configure XSENDFILE for storage/files

### DIFF
--- a/addons.conf
+++ b/addons.conf
@@ -11,9 +11,13 @@ map $http_user_agent $mobile_agents {
 server {
     listen  80 default;
 
-    # This is required to thwart nginx's file
-    # cache when using virtual box.
-    sendfile off;
+    location /code/storage/files/ {
+        internal;
+        # In addons-server, the main `docker-compose.yml` file mounts
+        # `./storage/files` as `/srv/user-media/addons`, so let's reuse it
+        # here.
+        alias /srv/user-media/addons/;
+    }
 
     location /static/ {
         alias /srv/static/;


### PR DESCRIPTION
This patch adds a new `location` that is XSENDFILE compliant, according to our production settings and https://www.nginx.com/resources/wiki/start/topics/examples/xsendfile/.