### PR TITLE
Allow to access addons-server's __version__ locally

### DIFF
--- a/addons.conf
+++ b/addons.conf
@@ -57,7 +57,11 @@ server {
     }
 
     location ~ "^/\w{2,3}(?:-\w{2,6})?/(?:firefox|android)/addon/[^/<>\"']+/statistics(?:$|/)" {
-      try_files $uri @olympia;
+        try_files $uri @olympia;
+    }
+
+    location /__version__ {
+        try_files $uri @olympia;
     }
 
     location / {


### PR DESCRIPTION
This could be useful, sometimes. It is actually used by [amo-info](https://addons.mozilla.org/en-US/firefox/addon/amo-info/) but I made a patch to add some information to `__version__` today and I wanted to try it out locally.